### PR TITLE
Update `Xmlrpc\Client` constructor behaviour

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -72,8 +72,16 @@ class Client
      * @return  void
      * @throws  \Hoa\Socket\Exception
      */
-    public function __construct(Socket\Client $client, $script)
+    public function __construct($client, $script)
     {
+        if( is_string($client) ) {
+            $client = new Socket\Client($client);
+        } elseif( !($client instanceof Socket\Client) ) {
+            throw new Exception(
+                'Client must be a valid Hoa\Socket\Client instance'
+            );
+        }
+
         $this->_client = $client;
         $this->_script = $script;
         $client->connect();

--- a/Client.php
+++ b/Client.php
@@ -67,8 +67,8 @@ class Client
     /**
      * Constructor.
      *
-     * @param   \Hoa\Socket\Client  $client    Client.
-     * @param   string              $script    Script.
+     * @param   string|\Hoa\Socket\Client  $client    Client.
+     * @param   string                     $script    Script.
      * @return  void
      * @throws  \Hoa\Socket\Exception
      */


### PR DESCRIPTION
Previously the constructors must be called with an instance of `Socket\Client` as the first parameter, now it can handle a string too.